### PR TITLE
ensure files owned by root and not uid as packaged

### DIFF
--- a/sun-java/init.sls
+++ b/sun-java/init.sls
@@ -11,7 +11,7 @@
 
 unpack-jdk-tarball:
   cmd.run:
-    - name: curl {{ java.dl_opts }} '{{ java.source_url }}' | tar xz
+    - name: curl {{ java.dl_opts }} '{{ java.source_url }}' | tar xz --no-same-owner
     - cwd: {{ java.prefix }}
     - unless: test -d {{ java.java_real_home }}
     - require:


### PR DESCRIPTION
Files should be owned by root, and not a random uid/gid which is specified inside the tar.
