### PR TITLE
parent-dirs of java.prefix might not exist

### DIFF
--- a/sun-java/init.sls
+++ b/sun-java/init.sls
@@ -8,6 +8,7 @@
     - user: root
     - group: root
     - mode: 755
+    - makedirs: True
 
 unpack-jdk-tarball:
   cmd.run:


### PR DESCRIPTION
equivalent of mkdir -p
