### PR TITLE
Add SHA256 checksum verification for JDK tarball and JCE zip archive

### DIFF
--- a/sun-java/jce.sls
+++ b/sun-java/jce.sls
@@ -2,6 +2,8 @@
 
 {%- if java.jce_url is defined %}
 
+  {%- set zip_file = 'UnlimitedJCEPolicy.zip' -%}
+
 include:
   - sun-java
 
@@ -10,21 +12,37 @@ unzip:
 
 download-jce-zip:
   cmd.run:
-    - name: curl {{ java.dl_opts }} '{{ java.jce_url }}' > UnlimitedJCEPolicy.zip
+    - name: curl {{ java.dl_opts }} -o '{{ zip_file }}' '{{ java.jce_url }}'
     - cwd: {{ java.jre_lib_sec }}
-    - unless: test -f {{ java.jre_lib_sec ~ "/UnlimitedJCEPolicy.zip" }}
+    - creates: {{ java.jre_lib_sec + '/' + zip_file }}
+    - require:
+      - archive: unpack-jdk-tarball
+
+  {%- if java.jce_hash %}
+
+check-sha256-hash:
+  cmd.run:
+    - name: sha256sum '{{ zip_file }}' | grep '^{{ java.jce_hash }} '
+    - cwd: {{ java.jre_lib_sec }}
+    - onchanges:
+      - cmd: download-jce-zip
+    - require_in:
+      - cmd: backup-non-jce-jar
+      - cmd: unpack-jce-zip
+
+  {%- endif %}
 
 backup-non-jce-jar:
   cmd.run:
     - name: mv US_export_policy.jar US_export_policy.jar.nonjce; mv local_policy.jar local_policy.jar.nonjce;
     - cwd: {{ java.jre_lib_sec }}
-    - unless: test -f {{ java.jre_lib_sec ~ "/US_export_policy.jar.nonjce" }}
+    - creates: {{ java.jre_lib_sec ~ "/US_export_policy.jar.nonjce" }}
 
 unpack-jce-zip:
   cmd.run:
-    - name: unzip -j UnlimitedJCEPolicy.zip
+    - name: unzip -j {{ zip_file }}
     - cwd: {{ java.jre_lib_sec }}
-    - unless: test -f {{ java.jre_lib_sec ~ "/US_export_policy.jar" }}
+    - creates: {{ java.jre_lib_sec ~ "/US_export_policy.jar" }}
     - require:
       - pkg: unzip
       - cmd: download-jce-zip

--- a/sun-java/settings.sls
+++ b/sun-java/settings.sls
@@ -1,29 +1,47 @@
 {% set p  = salt['pillar.get']('java', {}) %}
 {% set g  = salt['grains.get']('java', {}) %}
 
-{%- set java_home      = salt['grains.get']('java_home', salt['pillar.get']('java_home', '/usr/lib/java')) %}
+{%- set java_home            = salt['grains.get']('java_home', salt['pillar.get']('java_home', '/usr/lib/java')) %}
 
 {%- set default_version_name = 'jdk1.8.0_74' %}
 {%- set default_prefix       = '/usr/share/java' %}
 {%- set default_source_url   = 'http://download.oracle.com/otn-pub/java/jdk/8u74-b02/jdk-8u74-linux-x64.tar.gz' %}
+{%- set default_source_hash  = '0bfd5d79f776d448efc64cb47075a52618ef76aabb31fde21c5c1018683cdddd' %}
 {%- set default_jce_url      = 'http://download.oracle.com/otn-pub/java/jce/8/jce_policy-8.zip' %}
-{%- set default_dl_opts      = '-b oraclelicense=accept-securebackup-cookie -L' %}
+{%- set default_jce_hash     = 'f3020a3922efd6626c2fff45695d527f34a8020e938a49292561f18ad1320b59' %}
+{%- set default_dl_opts      = '-b oraclelicense=accept-securebackup-cookie -L -s' %}
 
-{%- set version_name   = g.get('version_name', p.get('version_name', default_version_name)) %}
-{%- set source_url     = g.get('source_url', p.get('source_url', default_source_url)) %}
-{%- set jce_url        = g.get('jce_url', p.get('jce_url', default_jce_url)) %}
-{%- set dl_opts        = g.get('dl_opts', p.get('dl_opts', default_dl_opts)) %}
-{%- set prefix         = g.get('prefix', p.get('prefix', default_prefix)) %}
-{%- set java_real_home = prefix + '/' + version_name %}
-{%- set jre_lib_sec    = java_real_home + '/jre/lib/security' %}
+{%- set version_name         = g.get('version_name', p.get('version_name', default_version_name)) %}
+{%- set source_url           = g.get('source_url', p.get('source_url', default_source_url)) %}
+
+{%- if source_url == default_source_url %}
+  {%- set source_hash        = default_source_hash %}
+{%- else %}
+  {%- set source_hash        = g.get('source_hash', p.get('source_hash', '')) %}
+{%- endif %}
+
+{%- set jce_url              = g.get('jce_url', p.get('jce_url', default_jce_url)) %}
+
+{%- if jce_url == default_jce_url %}
+  {%- set jce_hash           = default_jce_hash %}
+{%- else %}
+  {%- set jce_hash           = g.get('jce_hash', p.get('jce_hash', '')) %}
+{%- endif %}
+
+{%- set dl_opts              = g.get('dl_opts', p.get('dl_opts', default_dl_opts)) %}
+{%- set prefix               = g.get('prefix', p.get('prefix', default_prefix)) %}
+{%- set java_real_home       = prefix + '/' + version_name %}
+{%- set jre_lib_sec          = java_real_home + '/jre/lib/security' %}
 
 {%- set java = {} %}
 {%- do java.update( { 'version_name'   : version_name,
                       'source_url'     : source_url,
+                      'source_hash'    : source_hash,
                       'jce_url'        : jce_url,
+                      'jce_hash'       : jce_hash,
                       'dl_opts'        : dl_opts,
                       'java_home'      : java_home,
                       'prefix'         : prefix,
                       'java_real_home' : java_real_home,
-                      'jre_lib_sec'    : jre_lib_sec
-                  }) %}
+                      'jre_lib_sec'    : jre_lib_sec,
+                    } ) %}


### PR DESCRIPTION
Hello there,

Since Oracle provides only plain HTTP links for downloading Java archives, there is no way to be sure that you've downloaded a valid archive.
This PR allows to set a SHA256 checksum for a downloaded file. Verification step is optional and will be skipped if no hash provided in Pillar or Grain.
Hashes for the default archives are pre-set:
- JDK tarball hash taken from this page: https://www.oracle.com/webfolder/s/digest/8u74checksum.html
- JCE zip file doesn't have publicly available hash, so calculated it myself.

This is great formula, thanks!