### PR TITLE
Update Java default version and install cURL

### DIFF
--- a/sun-java/init.sls
+++ b/sun-java/init.sls
@@ -6,6 +6,9 @@
 
   {%- set tarball_file = java.prefix + '/' + java.source_url.split('/') | last %}
 
+curl:
+    pkg.installed
+
 java-install-dir:
   file.directory:
     - name: {{ java.prefix }}
@@ -20,6 +23,7 @@ download-jdk-tarball:
     - unless: test -d {{ java.java_real_home }} || test -f {{ tarball_file }}
     - require:
       - file: java-install-dir
+      - pkg: curl
 
 unpack-jdk-tarball:
   archive.extracted:

--- a/sun-java/settings.sls
+++ b/sun-java/settings.sls
@@ -3,10 +3,10 @@
 
 {%- set java_home            = salt['grains.get']('java_home', salt['pillar.get']('java_home', '/usr/lib/java')) %}
 
-{%- set default_version_name = 'jdk1.8.0_74' %}
+{%- set default_version_name = 'jdk1.8.0_121' %}
 {%- set default_prefix       = '/usr/share/java' %}
-{%- set default_source_url   = 'http://download.oracle.com/otn-pub/java/jdk/8u74-b02/jdk-8u74-linux-x64.tar.gz' %}
-{%- set default_source_hash  = '0bfd5d79f776d448efc64cb47075a52618ef76aabb31fde21c5c1018683cdddd' %}
+{%- set default_source_url   = 'http://download.oracle.com/otn-pub/java/jdk/8u121-b13/e9e7ea248e2c4826b92b3f075a80e441/server-jre-8u121-linux-x64.tar.gz' %}
+{%- set default_source_hash  = 'c25a60d02475499109f2bd6aa483721462aa7bfbb86b23ca6ac59be472747e5d' %}
 {%- set default_jce_url      = 'http://download.oracle.com/otn-pub/java/jce/8/jce_policy-8.zip' %}
 {%- set default_jce_hash     = 'f3020a3922efd6626c2fff45695d527f34a8020e938a49292561f18ad1320b59' %}
 {%- set default_dl_opts      = '-b oraclelicense=accept-securebackup-cookie -L -s' %}


### PR DESCRIPTION
Set the default Java version to the latest one (`1.8.0_121`) and includes the `curl` package installation as dependency (because used to download Java files).