### PR TITLE
Fix checking hash sum for JRE/JCE

### DIFF
--- a/sun-java/init.sls
+++ b/sun-java/init.sls
@@ -70,5 +70,7 @@ update-java-home-symlink:
 remove-jdk-archive:
   file.absent:
     - name: {{ archive_file }}
+    - require:
+      - archive: unpack-jdk-archive
 
 {%- endif %}

--- a/sun-java/init.sls
+++ b/sun-java/init.sls
@@ -21,13 +21,30 @@ download-jdk-tarball:
     - require:
       - file: java-install-dir
 
+  {%- if java.source_hash %}
+
+# FIXME: We need to check hash sum separately, because
+# ``archive.extracted`` state does not support integrity verification
+# for local archives prior to and including Salt release 2016.11.6.
+#
+# See: https://github.com/saltstack/salt/pull/41914
+
+check-jdk-tarball:
+  module.run:
+    - name: file.check_hash
+    - path: {{ tarball_file }}
+    - file_hash: {{ java.source_hash }}
+    - onchanges:
+      - download-jdk-tarball
+    - require_in:
+      - archive: unpack-jdk-tarball
+
+  {%- endif %}
+
 unpack-jdk-tarball:
   archive.extracted:
     - name: {{ java.prefix }}
     - source: file://{{ tarball_file }}
-    {%- if java.source_hash %}
-    - source_hash: sha256={{ java.source_hash }}
-    {%- endif %}
     - archive_format: tar
     - user: root
     - group: root

--- a/sun-java/jce.sls
+++ b/sun-java/jce.sls
@@ -7,15 +7,16 @@
 include:
   - sun-java
 
-unzip:
-  pkg.installed
+sun-java-jce-unzip:
+  pkg.installed:
+    - name: unzip
 
-download-jce-zip:
+download-jce-archive:
   cmd.run:
     - name: curl {{ java.dl_opts }} -o '{{ zip_file }}' '{{ java.jce_url }}'
     - creates: {{ zip_file }}
     - require:
-      - archive: unpack-jdk-tarball
+      - archive: unpack-jdk-archive
 
 # FIXME: use ``archive.extracted`` state.
 # Be aware that it does not support integrity verification
@@ -25,16 +26,16 @@ download-jce-zip:
 
   {%- if java.jce_hash %}
 
-check-jce-zip:
+check-jce-archive:
   module.run:
     - name: file.check_hash
     - path: {{ zip_file }}
     - file_hash: {{ java.jce_hash }}
     - onchanges:
-      - cmd: download-jce-zip
+      - cmd: download-jce-archive
     - require_in:
       - cmd: backup-non-jce-jar
-      - cmd: unpack-jce-zip
+      - cmd: unpack-jce-archive
 
   {%- endif %}
 
@@ -44,14 +45,14 @@ backup-non-jce-jar:
     - cwd: {{ java.jre_lib_sec }}
     - creates: {{ java.jre_lib_sec ~ "/US_export_policy.jar.nonjce" }}
 
-unpack-jce-zip:
+unpack-jce-archive:
   cmd.run:
     - name: unzip -j {{ zip_file }}
     - cwd: {{ java.jre_lib_sec }}
     - creates: {{ java.jre_lib_sec ~ "/US_export_policy.jar" }}
     - require:
       - pkg: unzip
-      - cmd: download-jce-zip
+      - cmd: download-jce-archive
       - cmd: backup-non-jce-jar
 
 {%- endif %}

--- a/sun-java/settings.sls
+++ b/sun-java/settings.sls
@@ -6,9 +6,10 @@
 {%- set default_version_name = 'jdk1.8.0_131' %}
 {%- set default_prefix       = '/usr/share/java' %}
 {%- set default_source_url   = 'http://download.oracle.com/otn-pub/java/jdk/8u131-b11/d54c1d3a095b4ff2b6607d096fa80163/jdk-8u131-linux-x64.tar.gz' %}
-{%- set default_source_hash  = '0bfd5d79f776d448efc64cb47075a52618ef76aabb31fde21c5c1018683cdddd' %}
+{# See Oracle Java SE checksums page here: https://www.oracle.com/webfolder/s/digest/8u131checksum.html #}
+{%- set default_source_hash  = 'sha256=62b215bdfb48bace523723cdbb2157c665e6a25429c73828a32f00e587301236' %}
 {%- set default_jce_url      = 'http://download.oracle.com/otn-pub/java/jce/8/jce_policy-8.zip' %}
-{%- set default_jce_hash     = 'f3020a3922efd6626c2fff45695d527f34a8020e938a49292561f18ad1320b59' %}
+{%- set default_jce_hash     = 'sha256=f3020a3922efd6626c2fff45695d527f34a8020e938a49292561f18ad1320b59' %}
 {%- set default_dl_opts      = '-b oraclelicense=accept-securebackup-cookie -L -s' %}
 
 {%- set version_name         = g.get('version_name', p.get('version_name', default_version_name)) %}


### PR DESCRIPTION
This PR brings back hash sum verifications for downloaded JRE tarball.
Unfortunately, Salt has had a bug, which caused complete ignorance of hash sum for local `file://` URI.
That should be fixed in upcoming Salt releases 2016.11.7 and 2017.7.0.
Related upstream PR is saltstack/salt#41914.
I propose to maintain a workaround for earlier versions.

@sroegner , please review.