### PR TITLE
Archive extracted update; update pillars for JDK 1.8.0_144 and #36

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -1,15 +1,20 @@
 java_home: /usr/lib/java
 java:
+  archive_type: tar
   source_url: http://download.oracle.com/otn-pub/java/jdk/8u131-b11/d54c1d3a095b4ff2b6607d096fa80163/jdk-8u131-linux-x64.tar.gz
   source_hash: sha256=62b215bdfb48bace523723cdbb2157c665e6a25429c73828a32f00e587301236
   jce_url: http://download.oracle.com/otn-pub/java/jce/8/jce_policy-8.zip
   jce_hash: sha256=f3020a3922efd6626c2fff45695d527f34a8020e938a49292561f18ad1320b59
   version_name: jdk1.8.0_131
   prefix: /usr/share/java
-  dl_opts: -L -s
+  dl_opts: -b oraclelicense=accept-securebackup-cookie -L -s
   java_real_home: /usr/share/java/jdk1.8.0_131
   jre_lib_sec: /usr/share/java/jdk1.8.0_131/jre/lib/security
-  alt_priority: 100000
+  alt_priority: 301800111
+  java_symlink: /usr/bin/java
+  javac_symlink: /usr/bin/javac
+  java_realcmd: /usr/share/java/jdk1.8.0_131/bin/java
+  javac_realcmd: /usr/share/java/jdk1.8.0_131/bin/javac
 
 # java:version_name is the name of the top-level directory inside the tarball
 # java:prefix is where the tarball is unpacked into - prefix/version_name being

--- a/pillar.example
+++ b/pillar.example
@@ -1,20 +1,21 @@
 java_home: /usr/lib/java
+# See Oracle Java SE checksums page here: https://www.oracle.com/webfolder/s/digest/8u144checksum.html
 java:
   archive_type: tar
-  source_url: http://download.oracle.com/otn-pub/java/jdk/8u131-b11/d54c1d3a095b4ff2b6607d096fa80163/jdk-8u131-linux-x64.tar.gz
-  source_hash: sha256=62b215bdfb48bace523723cdbb2157c665e6a25429c73828a32f00e587301236
+  source_url: http://download.oracle.com/otn-pub/java/jdk/8u144-b01/090f390dda5b47b9b721c7dfaa008135/jdk-8u144-linux-x64.tar.gz
+  source_hash: sha256=e8a341ce566f32c3d06f6d0f0eeea9a0f434f538d22af949ae58bc86f2eeaae4
   jce_url: http://download.oracle.com/otn-pub/java/jce/8/jce_policy-8.zip
   jce_hash: sha256=f3020a3922efd6626c2fff45695d527f34a8020e938a49292561f18ad1320b59
-  version_name: jdk1.8.0_131
+  version_name: jdk1.8.0_144
   prefix: /usr/share/java
   dl_opts: -b oraclelicense=accept-securebackup-cookie -L -s
-  java_real_home: /usr/share/java/jdk1.8.0_131
-  jre_lib_sec: /usr/share/java/jdk1.8.0_131/jre/lib/security
+  java_real_home: /usr/share/java/jdk1.8.0_144
+  jre_lib_sec: /usr/share/java/jdk1.8.0_144/jre/lib/security
   alt_priority: 301800111
   java_symlink: /usr/bin/java
   javac_symlink: /usr/bin/javac
-  java_realcmd: /usr/share/java/jdk1.8.0_131/bin/java
-  javac_realcmd: /usr/share/java/jdk1.8.0_131/bin/javac
+  java_realcmd: /usr/share/java/jdk1.8.0_144/bin/java
+  javac_realcmd: /usr/share/java/jdk1.8.0_144/bin/javac
 
 # java:version_name is the name of the top-level directory inside the tarball
 # java:prefix is where the tarball is unpacked into - prefix/version_name being

--- a/sun-java/init.sls
+++ b/sun-java/init.sls
@@ -54,8 +54,6 @@ unpack-jdk-archive:
     - name: {{ java.prefix }}
     - source: file://{{ archive_file }}
     - archive_format: {{ java.archive_type }}
-    - user: root
-    - group: root
   {% if grains['saltversioninfo'] < [2016, 11, 0] %}
      - if_missing: {{ java.java_realcmd }}
   {% endif %}

--- a/sun-java/init.sls
+++ b/sun-java/init.sls
@@ -57,7 +57,6 @@ unpack-jdk-archive:
   {% if grains['saltversioninfo'] < [2016, 11, 0] %}
      - if_missing: {{ java.java_realcmd }}
   {% endif %}
-    - if_missing: {{ java.java_realcmd }}
     - onchanges:
       - cmd: download-jdk-archive
 

--- a/sun-java/init.sls
+++ b/sun-java/init.sls
@@ -56,6 +56,9 @@ unpack-jdk-archive:
     - archive_format: {{ java.archive_type }}
     - user: root
     - group: root
+  {% if grains['saltversioninfo'] < [2016, 11, 0] %}
+     - if_missing: {{ java.java_realcmd }}
+  {% endif %}
     - if_missing: {{ java.java_realcmd }}
     - onchanges:
       - cmd: download-jdk-archive

--- a/sun-java/settings.sls
+++ b/sun-java/settings.sls
@@ -43,9 +43,9 @@
 {%- set java_real_home       = prefix + '/' + version_name %}
 {%- set jre_lib_sec          = java_real_home + '/jre/lib/security' %}
 {%- set java_symlink         = g.get('java_symlink', p.get('java_symlink', default_symlink )) %}
-{%- set java_realcmd         = g.get('java_realcmd', p.get('java_realcmd', java_real_home + '/bin/java' )) %}
+{%- set realcmd              = g.get('realcmd', p.get('realcmd', java_real_home + '/bin/java' )) %}
 {%- set javac_symlink        = java_symlink + 'c' %}
-{%- set javac_realcmd        = java_realcmd + 'c' %}
+{%- set javac_realcmd        = realcmd + 'c' %}
 {%- set alt_priority         = g.get('alt_priority', p.get('alt_priority', default_alt_priority )) %}
 
 {%- set java = {} %}
@@ -61,7 +61,7 @@
                       'jre_lib_sec'    : jre_lib_sec,
                       'archive_type'   : archive_type,
                       'java_symlink'   : java_symlink,
-                      'java_realcmd'   : java_realcmd,
+                      'realcmd'        : realcmd,
                       'javac_symlink'  : javac_symlink,
                       'javac_realcmd'  : javac_realcmd,
                       'alt_priority'   : alt_priority,

--- a/sun-java/settings.sls
+++ b/sun-java/settings.sls
@@ -5,14 +5,14 @@
 
 {%- set release              = '8' %}
 {%- set major                = '0' %}
-{%- set minor                = '131' %}
-{%- set build                = '-b11' %}
-{%- set dirhash              = '/d54c1d3a095b4ff2b6607d096fa80163/jdk-' %}
+{%- set minor                = '144' %}
+{%- set build                = '-b01' %}
+{%- set dirhash              = '/090f390dda5b47b9b721c7dfaa008135/jdk-' %}
 
 {%- set default_prefix       = '/usr/share/java' %}
 {%- set default_source_url   = 'http://download.oracle.com/otn-pub/java/jdk/' + release + 'u' + minor + build + dirhash + release + 'u' + minor + '-linux-x64.tar.gz' %}
-{# See Oracle Java SE checksums page here: https://www.oracle.com/webfolder/s/digest/8u131checksum.html #}
-{%- set default_source_hash  = 'sha256=62b215bdfb48bace523723cdbb2157c665e6a25429c73828a32f00e587301236' %}
+{# See Oracle Java SE checksums page here: https://www.oracle.com/webfolder/s/digest/8u144checksum.html #}
+{%- set default_source_hash  = 'sha256=e8a341ce566f32c3d06f6d0f0eeea9a0f434f538d22af949ae58bc86f2eeaae4' %}
 {%- set default_jce_url      = 'http://download.oracle.com/otn-pub/java/jce/' + release + '/jce_policy-' + release + '.zip' %}
 {%- set default_jce_hash     = 'sha256=f3020a3922efd6626c2fff45695d527f34a8020e938a49292561f18ad1320b59' %}
 {%- set default_dl_opts      = '-b oraclelicense=accept-securebackup-cookie -L -s' %}
@@ -43,7 +43,7 @@
 {%- set java_real_home       = prefix + '/' + version_name %}
 {%- set jre_lib_sec          = java_real_home + '/jre/lib/security' %}
 {%- set java_symlink         = g.get('java_symlink', p.get('java_symlink', default_symlink )) %}
-{%- set java_realcmd         = g.get('realcmd', p.get('realcmd', java_real_home + '/bin/java' )) %}
+{%- set java_realcmd         = g.get('java_realcmd', p.get('java_realcmd', java_real_home + '/bin/java' )) %}
 {%- set javac_symlink        = java_symlink + 'c' %}
 {%- set javac_realcmd        = java_realcmd + 'c' %}
 {%- set alt_priority         = g.get('alt_priority', p.get('alt_priority', default_alt_priority )) %}

--- a/sun-java/settings.sls
+++ b/sun-java/settings.sls
@@ -43,9 +43,9 @@
 {%- set java_real_home       = prefix + '/' + version_name %}
 {%- set jre_lib_sec          = java_real_home + '/jre/lib/security' %}
 {%- set java_symlink         = g.get('java_symlink', p.get('java_symlink', default_symlink )) %}
-{%- set realcmd              = g.get('realcmd', p.get('realcmd', java_real_home + '/bin/java' )) %}
+{%- set java_realcmd         = g.get('realcmd', p.get('realcmd', java_real_home + '/bin/java' )) %}
 {%- set javac_symlink        = java_symlink + 'c' %}
-{%- set javac_realcmd        = realcmd + 'c' %}
+{%- set javac_realcmd        = java_realcmd + 'c' %}
 {%- set alt_priority         = g.get('alt_priority', p.get('alt_priority', default_alt_priority )) %}
 
 {%- set java = {} %}
@@ -61,7 +61,7 @@
                       'jre_lib_sec'    : jre_lib_sec,
                       'archive_type'   : archive_type,
                       'java_symlink'   : java_symlink,
-                      'realcmd'        : realcmd,
+                      'java_realcmd'   : java_realcmd,
                       'javac_symlink'  : javac_symlink,
                       'javac_realcmd'  : javac_realcmd,
                       'alt_priority'   : alt_priority,


### PR DESCRIPTION
PR with two minor updates.

1. Salt 2016.11  generates "Bad state return directory" warnings (see saltstack/salt#39751). Solution is remove "user: root" and "group: root".

2. With rewrite for 2016.11.0, if_missing workaround depreciated. Solution: if block.

3. Update pillar.example for #36 and JDK 1.8.0_144

Tested on OpenSuSE Leap / Salt 2013.3 (no pillars)