### PR TITLE
Fedorafix #33

### DIFF
--- a/sun-java/init.sls
+++ b/sun-java/init.sls
@@ -60,8 +60,8 @@ unpack-jdk-archive:
     - onchanges:
       - cmd: download-jdk-archive
 
-# Game of Thrones - Redhat family issue #33
-# Fedora makes /usr/lib/java directory but tradition wants JAVA_HOME syslink.
+# Redhat family issue #33
+# Fedora makes /usr/lib/java directory but tradition wants JAVA_HOME symlink.
 # Remove Fedora contents of /usr/lib/java pending new symlink (i.e. onchanges)
 {%- if salt['grains.get']('os_family') == 'RedHat' %}
 sun-java-usrlibjava-fedora-uninstall:
@@ -87,7 +87,7 @@ update-javahome-symlink:
     - require:
       - archive: unpack-jdk-archive
 
-# Game of Thrones - Redhat family issue #33
+# Redhat family issue #33
 # Restore contents of Fedora packages to current /usr/lib/java
 {%- if salt['grains.get']('os_family') == 'RedHat' %}
 sun-java-usrlibjava-fedora-reinstall:

--- a/sun-java/init.sls
+++ b/sun-java/init.sls
@@ -14,7 +14,7 @@ java-install-dir:
     - mode: 755
     - makedirs: True
 
-# curl fails (rc=23) if file exists (interrupte formula?)
+# curl fails (rc=23) if file exists (interrupted formula?)
 # and test -f cannot detect corrupted archive
 sun-java-remove-prev-archive:
   file.absent:

--- a/sun-java/init.sls
+++ b/sun-java/init.sls
@@ -89,7 +89,7 @@ update-javahome-symlink:
 
 # Game of Thrones - Redhat family issue #33
 # Restore contents of Fedora packages to current /usr/lib/java
-{%- if salt['file.directory_exists']('/usr/lib/java') and salt['grains.get']('os_family') == 'RedHat' %}
+{%- if salt['grains.get']('os_family') == 'RedHat' %}
 sun-java-usrlibjava-fedora-reinstall:
   pkg.installed:
     - pkgs:

--- a/sun-java/settings.sls
+++ b/sun-java/settings.sls
@@ -45,7 +45,7 @@
 {%- set java_symlink         = g.get('java_symlink', p.get('java_symlink', default_symlink )) %}
 {%- set java_realcmd         = g.get('realcmd', p.get('realcmd', java_real_home + '/bin/java' )) %}
 {%- set javac_symlink        = java_symlink + 'c' %}
-{%- set javac_realcmd        = realcmd + 'c' %}
+{%- set javac_realcmd        = java_realcmd + 'c' %}
 {%- set alt_priority         = g.get('alt_priority', p.get('alt_priority', default_alt_priority )) %}
 
 {%- set java = {} %}

--- a/sun-java/settings.sls
+++ b/sun-java/settings.sls
@@ -43,7 +43,7 @@
 {%- set java_real_home       = prefix + '/' + version_name %}
 {%- set jre_lib_sec          = java_real_home + '/jre/lib/security' %}
 {%- set java_symlink         = g.get('java_symlink', p.get('java_symlink', default_symlink )) %}
-{%- set realcmd              = g.get('realcmd', p.get('realcmd', java_real_home + '/bin/java' )) %}
+{%- set java_realcmd         = g.get('realcmd', p.get('realcmd', java_real_home + '/bin/java' )) %}
 {%- set javac_symlink        = java_symlink + 'c' %}
 {%- set javac_realcmd        = realcmd + 'c' %}
 {%- set alt_priority         = g.get('alt_priority', p.get('alt_priority', default_alt_priority )) %}
@@ -61,7 +61,7 @@
                       'jre_lib_sec'    : jre_lib_sec,
                       'archive_type'   : archive_type,
                       'java_symlink'   : java_symlink,
-                      'realcmd'        : realcmd,
+                      'java_realcmd'   : java_realcmd,
                       'javac_symlink'  : javac_symlink,
                       'javac_realcmd'  : javac_realcmd,
                       'alt_priority'   : alt_priority,

--- a/sun-java/settings.sls
+++ b/sun-java/settings.sls
@@ -43,9 +43,9 @@
 {%- set java_real_home       = prefix + '/' + version_name %}
 {%- set jre_lib_sec          = java_real_home + '/jre/lib/security' %}
 {%- set java_symlink         = g.get('java_symlink', p.get('java_symlink', default_symlink )) %}
-{%- set java_realcmd         = g.get('realcmd', p.get('realcmd', java_real_home + '/bin/java' )) %}
+{%- set realcmd              = g.get('realcmd', p.get('realcmd', java_real_home + '/bin/java' )) %}
 {%- set javac_symlink        = java_symlink + 'c' %}
-{%- set javac_realcmd        = java_realcmd + 'c' %}
+{%- set javac_realcmd        = realcmd + 'c' %}
 {%- set alt_priority         = g.get('alt_priority', p.get('alt_priority', default_alt_priority )) %}
 
 {%- set java = {} %}
@@ -61,7 +61,7 @@
                       'jre_lib_sec'    : jre_lib_sec,
                       'archive_type'   : archive_type,
                       'java_symlink'   : java_symlink,
-                      'java_realcmd'   : java_realcmd,
+                      'realcmd'        : realcmd,
                       'javac_symlink'  : javac_symlink,
                       'javac_realcmd'  : javac_realcmd,
                       'alt_priority'   : alt_priority,


### PR DESCRIPTION
The following PR resolves #33 

Tested on Fedora 27 / Salt 2016.11

Visual check:
1.  /usr/lib/java/ is now symlink
2. Previous contents of directory /usr/lib/java are restored to current /usr/lib/java location (which changes everytime new jdk is installed).
