### PR TITLE
Resolve JRE issue #37 - javac alternative handling

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -1,26 +1,36 @@
 java_home: /usr/lib/java
 # See Oracle Java SE checksums page here: https://www.oracle.com/webfolder/s/digest/8u144checksum.html
 java:
-  ### Values should refer to either 'jdk' or 'jre' not both. #####
-  source_url: http://download.oracle.com/otn-pub/java/jdk/8u144-b01/090f390dda5b47b9b721c7dfaa008135/jdk-8u144-linux-x64.tar.gz
-  source_hash: sha256=e8a341ce566f32c3d06f6d0f0eeea9a0f434f538d22af949ae58bc86f2eeaae4
-  jce_url: http://download.oracle.com/otn-pub/java/jce/8/jce_policy-8.zip
-  jce_hash: sha256=f3020a3922efd6626c2fff45695d527f34a8020e938a49292561f18ad1320b59
-  version_name: jdk1.8.0_144
-  dl_opts: -b oraclelicense=accept-securebackup-cookie -L -s
   prefix: /usr/share/java
   java_symlink: /usr/bin/java
-  jre_lib_sec: /usr/share/java/jdk1.8.0_144/jre/lib/security
-  java_real_home: /usr/share/java/jdk1.8.0_144
-  java_realcmd: /usr/share/java/jdk1.8.0_144/bin/java
+  javac_symlink: /usr/bin/javac
+  dl_opts: -b oraclelicense=accept-securebackup-cookie -L -s
   alt_priority: 301800111
   archive_type: tar
 
-  ### javac applies to jdk only ###
-  javac_symlink: /usr/bin/javac
-  javac_realcmd: /usr/share/java/jdk1.8.0_144/bin/javac
+  ## JDK ##
+  # version_name: jdk1.8.0_144
+  # source_url: http://download.oracle.com/otn-pub/java/jdk/8u144-b01/090f390dda5b47b9b721c7dfaa008135/jdk-8u144-linux-x64.tar.gz
+  # source_hash: sha256=e8a341ce566f32c3d06f6d0f0eeea9a0f434f538d22af949ae58bc86f2eeaae4
+  # jre_lib_sec: /usr/share/java/jdk1.8.0_144/jre/lib/security
+  # java_real_home: /usr/share/java/jdk1.8.0_144
+  # java_realcmd: /usr/share/java/jdk1.8.0_144/bin/java
+  # javac_realcmd: /usr/share/java/jdk1.8.0_144/bin/javac
+
+  ## or JRE ##
+  version_name: jre1.8.0_144
+  source_url: http://download.oracle.com/otn-pub/java/jdk/8u144-b01/090f390dda5b47b9b721c7dfaa008135/jre-8u144-linux-x64.tar.gz
+  source_hash: sha256=4e6e11aad54ae3c716a5607ee88d81f3f1e8b5b23ee474b0272dba351ee9f28a
+  jre_lib_sec: /usr/share/java/jre1.8.0_144/jre/lib/security
+  java_real_home: /usr/share/java/jre1.8.0_144
+  java_realcmd: /usr/share/java/jre1.8.0_144/bin/java
+  javac_realcmd:
+
+  ## and JCE ##
+  jce_url: http://download.oracle.com/otn-pub/java/jce/8/jce_policy-8.zip
+  jce_hash: sha256=f3020a3922efd6626c2fff45695d527f34a8020e938a49292561f18ad1320b59
 
 # java:version_name is the name of the top-level directory inside the tarball
 # java:prefix is where the tarball is unpacked into - prefix/version_name being
-#             the location of the jdk
+#             the location of the jdk or jre
 # java:dl_opts - cli args to cURL

--- a/pillar.example
+++ b/pillar.example
@@ -9,22 +9,22 @@ java:
   archive_type: tar
 
   ## JDK ##
-  # version_name: jdk1.8.0_144
-  # source_url: http://download.oracle.com/otn-pub/java/jdk/8u144-b01/090f390dda5b47b9b721c7dfaa008135/jdk-8u144-linux-x64.tar.gz
-  # source_hash: sha256=e8a341ce566f32c3d06f6d0f0eeea9a0f434f538d22af949ae58bc86f2eeaae4
-  # jre_lib_sec: /usr/share/java/jdk1.8.0_144/jre/lib/security
-  # java_real_home: /usr/share/java/jdk1.8.0_144
-  # java_realcmd: /usr/share/java/jdk1.8.0_144/bin/java
-  # javac_realcmd: /usr/share/java/jdk1.8.0_144/bin/javac
+  version_name: jdk1.8.0_144
+  source_url: http://download.oracle.com/otn-pub/java/jdk/8u144-b01/090f390dda5b47b9b721c7dfaa008135/jdk-8u144-linux-x64.tar.gz
+  source_hash: sha256=e8a341ce566f32c3d06f6d0f0eeea9a0f434f538d22af949ae58bc86f2eeaae4
+  jre_lib_sec: /usr/share/java/jdk1.8.0_144/jre/lib/security
+  java_real_home: /usr/share/java/jdk1.8.0_144
+  java_realcmd: /usr/share/java/jdk1.8.0_144/bin/java
+  javac_realcmd: /usr/share/java/jdk1.8.0_144/bin/javac
 
   ## or JRE ##
-  version_name: jre1.8.0_144
-  source_url: http://download.oracle.com/otn-pub/java/jdk/8u144-b01/090f390dda5b47b9b721c7dfaa008135/jre-8u144-linux-x64.tar.gz
-  source_hash: sha256=4e6e11aad54ae3c716a5607ee88d81f3f1e8b5b23ee474b0272dba351ee9f28a
-  jre_lib_sec: /usr/share/java/jre1.8.0_144/jre/lib/security
-  java_real_home: /usr/share/java/jre1.8.0_144
-  java_realcmd: /usr/share/java/jre1.8.0_144/bin/java
-  javac_realcmd:
+  # version_name: jre1.8.0_144
+  # source_url: http://download.oracle.com/otn-pub/java/jdk/8u144-b01/090f390dda5b47b9b721c7dfaa008135/jre-8u144-linux-x64.tar.gz
+  # source_hash: sha256=4e6e11aad54ae3c716a5607ee88d81f3f1e8b5b23ee474b0272dba351ee9f28a
+  # jre_lib_sec: /usr/share/java/jre1.8.0_144/jre/lib/security
+  # java_real_home: /usr/share/java/jre1.8.0_144
+  # java_realcmd: /usr/share/java/jre1.8.0_144/bin/java
+  # javac_realcmd:
 
   ## and JCE ##
   jce_url: http://download.oracle.com/otn-pub/java/jce/8/jce_policy-8.zip

--- a/pillar.example
+++ b/pillar.example
@@ -1,6 +1,7 @@
 java_home: /usr/lib/java
 # See Oracle Java SE checksums page here: https://www.oracle.com/webfolder/s/digest/8u144checksum.html
 java:
+  ### Values should refer to either 'jdk' or 'jre' not both. #####
   source_url: http://download.oracle.com/otn-pub/java/jdk/8u144-b01/090f390dda5b47b9b721c7dfaa008135/jdk-8u144-linux-x64.tar.gz
   source_hash: sha256=e8a341ce566f32c3d06f6d0f0eeea9a0f434f538d22af949ae58bc86f2eeaae4
   jce_url: http://download.oracle.com/otn-pub/java/jce/8/jce_policy-8.zip
@@ -12,10 +13,12 @@ java:
   jre_lib_sec: /usr/share/java/jdk1.8.0_144/jre/lib/security
   java_real_home: /usr/share/java/jdk1.8.0_144
   java_realcmd: /usr/share/java/jdk1.8.0_144/bin/java
-  javac_symlink: /usr/bin/javac
-  javac_realcmd: /usr/share/java/jdk1.8.0_144/bin/javac
   alt_priority: 301800111
   archive_type: tar
+
+  ### javac applies to jdk only ###
+  javac_symlink: /usr/bin/javac
+  javac_realcmd: /usr/share/java/jdk1.8.0_144/bin/javac
 
 # java:version_name is the name of the top-level directory inside the tarball
 # java:prefix is where the tarball is unpacked into - prefix/version_name being

--- a/sun-java/env.sls
+++ b/sun-java/env.sls
@@ -45,7 +45,7 @@ java-alt-set:
     - require:
       - alternatives: java-alt-install
 
-# Add javac to alternatives
+# Add javac to alternatives if found
 javac-alt-install:
   alternatives.install:
     - name: javac
@@ -56,7 +56,7 @@ javac-alt-install:
       - alternatives: java-alt-set
     - onlyif: test -f {{ java.javac_realcmd }}
 
-# ensure javac alternative
+# ensure javac alternative if found
 javac-alt-set:
   alternatives.set:
     - name: javac

--- a/sun-java/env.sls
+++ b/sun-java/env.sls
@@ -22,10 +22,10 @@ javahome-alt-install:
 # ensure javahome alternative
 javahome-alt-set:
   alternatives.set:
-  - name: java-home
-  - path: {{ java.java_real_home }}
-  - require:
-    - alternatives: javahome-alt-install
+    - name: java-home
+    - path: {{ java.java_real_home }}
+    - require:
+      - alternatives: javahome-alt-install
 
 # Add java to alternatives
 java-alt-install:
@@ -40,10 +40,10 @@ java-alt-install:
 # ensure java alternative
 java-alt-set:
   alternatives.set:
-  - name: java
-  - path: {{ java.java_realcmd }}
-  - require:
-    - alternatives: java-alt-install
+    - name: java
+    - path: {{ java.java_realcmd }}
+    - require:
+      - alternatives: java-alt-install
 
 # Add javac to alternatives
 javac-alt-install:
@@ -54,12 +54,14 @@ javac-alt-install:
     - priority: {{ java.alt_priority }}
     - require:
       - alternatives: java-alt-set
+    - onlyif: test -f {{ java.javac_realcmd }}
 
 # ensure javac alternative
 javac-alt-set:
   alternatives.set:
-  - name: javac
-  - path: {{ java.javac_realcmd }}
-  - require:
-    - alternatives: javac-alt-install
+    - name: javac
+    - path: {{ java.javac_realcmd }}
+    - require:
+      - alternatives: javac-alt-install
+    - onlyif: test -f {{ java.javac_realcmd }}
 


### PR DESCRIPTION
This PR is resolution for #37 regression test failure with JRE-only binary. Two files are updated:-

pillar.example:
- Include verified JRE pillar values (commented out) included for documentation.

env.sls:
- Include onlyif check for javac-alt-install and javac-alt-set states.
- consistent formatting.

Tested Ubuntu 17/Fedora 26/Suse Leap and JRE 1.8.0.144