### PR TITLE
Support for MacOS Darwin

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -32,4 +32,5 @@ Downloads and installs the Java Cryptography Extension (JCE) Unlimited Strength 
 
 An addition to allow easy use - places a java profile in /etc/profile.d - this way JAVA_HOME and the PATH are set correctly for all system users.
 
-Tested on RedHat/CentOS 5.X or RedHat/CentOS 6.X, AmazonOS and Ubuntu.
+
+Verified on Linux and MacOS.

--- a/pillar.example
+++ b/pillar.example
@@ -1,5 +1,6 @@
 java_home: /usr/lib/java
-# See Oracle Java SE checksums page here: https://www.oracle.com/webfolder/s/digest/8u162checksum.html
+# See Oracle Java SE checksums page here: https://www.oracle.com/webfolder/s/digest/8u172checksum.html
+# Use /usr/local & /Library/Java/JavaVirtualMachines for MacOS: https://support.apple.com/en-ie/HT204899
 java:
   prefix: /usr/share/java
   java_symlink: /usr/bin/java
@@ -12,21 +13,31 @@ java:
   # alt_priority: 301800111
 
   ## JDK ##
-  version_name: jdk1.8.0_162
-  source_url: http://download.oracle.com/otn-pub/java/jdk/8u162-b12/0da788060d494f5095bf8624735fa2f1/jdk-8u162-linux-x64.tar.gz
-  source_hash: sha256=68ec82d47fd9c2b8eb84225b6db398a72008285fafc98631b1ff8d2229680257
-  jre_lib_sec: /usr/share/java/jdk1.8.0_162/jre/lib/security
-  java_real_home: /usr/share/java/jdk1.8.0_162
-  java_realcmd: /usr/share/java/jdk1.8.0_162/bin/java
-  javac_realcmd: /usr/share/java/jdk1.8.0_162/bin/javac
+  version_name: jdk1.8.0_172
+  ## linux
+  source_url: http://download.oracle.com/otn-pub/java/jdk/8u172-b11/a58eab1ec242421181065cdc37240b08/jdk-8u172-linux-x64.tar.gz
+  source_hash: sha256=28a00b9400b6913563553e09e8024c286b506d8523334c93ddec6c9ec7e9d346
+  ## macos
+  # source_url: http://download.oracle.com/otn-pub/java/jdk/8u172-b11/a58eab1ec242421181065cdc37240b08/jdk-8u172-macosx-x64.dmg
+  # source_hash: sha256=b0de04d3ec7fbf2e54e33e29c78ababa0a4df398ba490d4abb125b31ea8d663e
+
+  jre_lib_sec: /usr/share/java/jdk1.8.0_172/jre/lib/security
+  java_real_home: /usr/share/java/jdk1.8.0_172
+  java_realcmd: /usr/share/java/jdk1.8.0_172/bin/java
+  javac_realcmd: /usr/share/java/jdk1.8.0_172/bin/javac
 
   ## or JRE ##
-  # version_name: jre1.8.0_162
-  # source_url: http://download.oracle.com/otn-pub/java/jdk/8u162-b12/0da788060d494f5095bf8624735fa2f1/jre-8u162-linux-x64.tar.gz
-  # source_hash: sha256=dfa25ebd1f90bf74ad7ba2dacb0e08d884594e733c9a522b58256778031341a4
-  # jre_lib_sec: /usr/share/java/jre1.8.0_162/jre/lib/security
-  # java_real_home: /usr/share/java/jre1.8.0_162
-  # java_realcmd: /usr/share/java/jre1.8.0_162/bin/java
+  # version_name: jre1.8.0_172
+  ## linux
+  # source_url: http://download.oracle.com/otn-pub/java/jdk/8u172-b11/a58eab1ec242421181065cdc37240b08/jre-8u172-linux-x64.tar.gz
+  # source_hash: sha256=f08f25aec2bdc86138ccba8fd5b904451e3afa1d24a88c85f28c2d84bfd45bad
+  ## macos
+  # source_url: http://download.oracle.com/otn-pub/java/jdk/8u172-b11/a58eab1ec242421181065cdc37240b08/jre-8u172-macosx-x64.dmg
+  # source_hash: sha256=256acd1a6157e8c8d5413ff67eab138b959234c8ce4f25f1bb19aa9ea428e685
+
+  # jre_lib_sec: /usr/share/java/jre1.8.0_172/jre/lib/security
+  # java_real_home: /usr/share/java/jre1.8.0_172
+  # java_realcmd: /usr/share/java/jre1.8.0_172/bin/java
   # javac_realcmd:
 
   ## and JCE ##

--- a/sun-java/env.sls
+++ b/sun-java/env.sls
@@ -9,7 +9,8 @@ jdk-config:
     - template: jinja
     - mode: 644
     - user: root
-    - group: root
+    - group: {{ java.group }}
+    - unless: test "`uname`" = "Darwin"
     - context:
       java_home: {{ java.java_home }}
 
@@ -24,6 +25,8 @@ java-link:
   file.symlink:
     - name: {{ java.java_symlink }}
     - target: {{ java.java_realcmd }}
+    - onlyif: test -f {{ java.java_realcmd }}
+    - force: true
     - require:
       - file: javahome-link
 
@@ -32,6 +35,7 @@ javac-link:
     - name: {{ java.javac_symlink }}
     - target: {{ java.javac_realcmd }}
     - onlyif: test -f {{ java.javac_realcmd }}
+    - force: true
     - require:
       - file: java-link
 

--- a/sun-java/settings.sls
+++ b/sun-java/settings.sls
@@ -1,26 +1,43 @@
 {% set p  = salt['pillar.get']('java', {}) %}
 {% set g  = salt['grains.get']('java', {}) %}
 
-{%- set java_home            = salt['grains.get']('java_home', salt['pillar.get']('java_home', '/usr/lib/java')) %}
-
 {%- set release              = '8' %}
 {%- set major                = '0' %}
-{%- set minor                = '162' %}
-{%- set build                = '-b12' %}
-{%- set dirhash              = '/0da788060d494f5095bf8624735fa2f1/jdk-' %}
+{%- set minor                = '172' %}
+{%- set build                = '-b11' %}
+{%- set dirhash              = '/a58eab1ec242421181065cdc37240b08/jdk-' %}
 
-{%- set default_prefix       = '/usr/share/java' %}
-{%- set default_source_url   = 'http://download.oracle.com/otn-pub/java/jdk/' + release + 'u' + minor + build + dirhash + release + 'u' + minor + '-linux-x64.tar.gz' %}
-{# See Oracle Java SE checksums page here: https://www.oracle.com/webfolder/s/digest/8u162checksum.html #}
-{%- set default_source_hash  = 'sha256=68ec82d47fd9c2b8eb84225b6db398a72008285fafc98631b1ff8d2229680257' %}
-{%- set default_jce_url      = 'http://download.oracle.com/otn-pub/java/jce/' + release + '/jce_policy-' + release + '.zip' %}
-{%- set default_jce_hash     = 'sha256=f3020a3922efd6626c2fff45695d527f34a8020e938a49292561f18ad1320b59' %}
-{%- set default_dl_opts      = '-b oraclelicense=accept-securebackup-cookie -L -s' %}
-{%- set default_symlink      = '/usr/bin/java' %}
+{# See Oracle Java SE checksums page here: https://www.oracle.com/webfolder/s/digest/8u172checksum.html #}
+{%- set default_jce_hash = 'sha256=f3020a3922efd6626c2fff45695d527f34a8020e938a49292561f18ad1320b59' %}
 
 {%- set default_version_name = 'jdk1.' + release + '.' + major + '_' + minor %}
-{%- set archive_type         = g.get('archive_type', p.get('archive_type', 'tar' )) %}
 {%- set version_name         = g.get('version_name', p.get('version_name', default_version_name)) %}
+
+{% if grains.os == 'MacOS' %}
+  {% set archive = '-macosx-x64.dmg' %}
+  {% set default_source_hash = 'sha256=b0de04d3ec7fbf2e54e33e29c78ababa0a4df398ba490d4abb125b31ea8d663e' %}
+  {% set group = 'wheel' %}
+  {% set archive_type = g.get('archive_type', p.get('archive_type', 'dmg' )) %}
+  {% set java_home = salt['grains.get']('java_home', salt['pillar.get']('java_home', '/usr/local/lib/java')) %}
+  {% set prefix    = g.get('prefix', p.get('prefix', '/Library/Java/JavaVirtualMachines')) %}
+  {% set default_symlink = '/usr/local/bin/java' %}
+  {% set java_real_home = g.get('java_real_home', p.get('java_real_home', prefix + '/' + version_name + '.jdk/Contents/Home' )) %}
+{% else %}
+  {%- set archive = '-linux-x64.tar.gz' %}
+  {%- set default_source_hash = 'sha256=28a00b9400b6913563553e09e8024c286b506d8523334c93ddec6c9ec7e9d346' %}
+  {%- set group = 'root' %}
+  {%- set archive_type = g.get('archive_type', p.get('archive_type', 'tar' )) %}
+  {%- set java_home = salt['grains.get']('java_home', salt['pillar.get']('java_home', '/usr/lib/java')) %}
+  {%- set prefix    = g.get('prefix', p.get('prefix', '/usr/share/java')) %}
+  {%- set default_symlink = '/usr/bin/java' %}
+  {%- set java_real_home  = g.get('java_real_home', p.get('java_real_home', prefix + '/' + version_name )) %}
+{% endif %}
+
+{%- set uri = 'http://download.oracle.com/otn-pub/java/jdk/' %}
+{%- set default_source_url = uri + release + 'u' + minor + build + dirhash + release + 'u' + minor + archive %}
+{%- set default_jce_url    = uri + release + '/jce_policy-' + release + '.zip' %}
+{%- set default_dl_opts      = '-b oraclelicense=accept-securebackup-cookie -L -s' %}
+
 {%- set source_url           = g.get('source_url', p.get('source_url', default_source_url)) %}
 
 {%- if source_url == default_source_url %}
@@ -38,8 +55,6 @@
 {%- endif %}
 
 {%- set dl_opts              = g.get('dl_opts', p.get('dl_opts', default_dl_opts)) %}
-{%- set prefix               = g.get('prefix', p.get('prefix', default_prefix)) %}
-{%- set java_real_home       = g.get('java_real_home', p.get('java_real_home', prefix + '/' + version_name )) %}
 {%- set jre_lib_sec          = g.get('jre_lib_sec', p.get('jre_lib_sec', java_real_home + '/jre/lib/security' )) %}
 {%- set java_symlink         = g.get('java_symlink', p.get('java_symlink', default_symlink )) %}
 {%- set java_realcmd         = g.get('realcmd', p.get('realcmd', java_real_home + '/bin/java' )) %}
@@ -56,6 +71,7 @@
                       'dl_opts'        : dl_opts,
                       'java_home'      : java_home,
                       'prefix'         : prefix,
+                      'group'          : group,
                       'java_real_home' : java_real_home,
                       'jre_lib_sec'    : jre_lib_sec,
                       'archive_type'   : archive_type,


### PR DESCRIPTION
This PR introduces support for Darwin.  tested on MacOS High Sierra.

```
[WARNING ] The function "module.run" is using its deprecated version and will expire in version "Sodium".
[ERROR   ] Command '/usr/libexec/PlistBuddy -c "print :CFBundleIdentifier" ''"'"'/tmp/dmg-ThzeS9/*.pkg'"'"'/Contents/Info.plist'' failed with return code: 1
[ERROR   ] output: Print: Entry, ":CFBundleIdentifier", Does Not Exist
File Doesn't Exist, Will Create: '/tmp/dmg-ThzeS9/*.pkg'/Contents/Info.plist
[WARNING ] The function "module.run" is using its deprecated version and will expire in version "Sodium".
[ERROR   ] {u'ret': False}
local:
----------
          ID: java-install-dir
    Function: file.directory
        Name: /Library/Java/JavaVirtualMachines
      Result: True
     Comment: The directory /Library/Java/JavaVirtualMachines is in the correct state
     Started: 19:35:25.068538
    Duration: 0.835 ms
     Changes:   
----------
          ID: sun-java-remove-prev-archive
    Function: file.absent
        Name: /Library/Java/JavaVirtualMachines/jdk-8u172-macosx-x64.dmg
      Result: True
     Comment: File /Library/Java/JavaVirtualMachines/jdk-8u172-macosx-x64.dmg is not present
     Started: 19:35:25.069708
    Duration: 0.244 ms
     Changes:   
----------
          ID: download-jdk-archive
    Function: cmd.run
        Name: curl -b oraclelicense=accept-securebackup-cookie -L -s -o '/Library/Java/JavaVirtualMachines/jdk-8u172-macosx-x64.dmg' 'http://download.oracle.com/otn-pub/java/jdk/8u172-b11/a58eab1ec242421181065cdc37240b08/jdk-8u172-macosx-x64.dmg'
      Result: True
     Comment: Command "curl -b oraclelicense=accept-securebackup-cookie -L -s -o '/Library/Java/JavaVirtualMachines/jdk-8u172-macosx-x64.dmg' 'http://download.oracle.com/otn-pub/java/jdk/8u172-b11/a58eab1ec242421181065cdc37240b08/jdk-8u172-macosx-x64.dmg'" run
     Started: 19:35:25.070736
    Duration: 636534.922 ms
     Changes:   
              ----------
              pid:
                  83058
              retcode:
                  0
              stderr:
              stdout:
----------
          ID: check-jdk-archive
    Function: module.run
        Name: file.check_hash
      Result: True
     Comment: Module function file.check_hash executed
     Started: 19:46:01.607533
    Duration: 656.862 ms
     Changes:   
              ----------
              ret:
                  True
----------
          ID: unpack-jdk-archive
    Function: archive.extracted
        Name: /Library/Java/JavaVirtualMachines
      Result: True
     Comment: unless condition is true
     Started: 19:46:02.265975
    Duration: 3100.605 ms
     Changes:   
----------
          ID: unpack-jdk-macpackage
    Function: macpackage.installed
        Name: /Library/Java/JavaVirtualMachines/jdk-8u172-macosx-x64.dmg
      Result: True
     Comment: /Library/Java/JavaVirtualMachines/jdk-8u172-macosx-x64.dmg installed
     Started: 19:46:05.367073
    Duration: 8950.996 ms
     Changes:   
              ----------
              installed:
----------
          ID: update-javahome-symlink
    Function: file.symlink
        Name: /usr/local/lib/java
      Result: True
     Comment: Created new symlink /usr/local/lib/java -> /Library/Java/JavaVirtualMachines/jdk1.8.0_172.jdk/Contents/Home
     Started: 19:46:14.319464
    Duration: 28.007 ms
     Changes:   
              ----------
              new:
                  /usr/local/lib/java
----------
          ID: remove-jdk-archive
    Function: file.absent
        Name: /Library/Java/JavaVirtualMachines/jdk-8u172-macosx-x64.dmg
      Result: True
     Comment: Removed file /Library/Java/JavaVirtualMachines/jdk-8u172-macosx-x64.dmg
     Started: 19:46:14.347973
    Duration: 15.685 ms
     Changes:   
              ----------
              removed:
                  /Library/Java/JavaVirtualMachines/jdk-8u172-macosx-x64.dmg
----------
          ID: sun-java-jce-unzip
    Function: pkg.installed
        Name: unzip
      Result: True
     Comment: All specified packages are already installed
     Started: 19:46:14.372324
    Duration: 641.787 ms
     Changes:   
----------
          ID: sun-java-remove-old-jce-archive
    Function: file.absent
        Name: /usr/local/lib/java/jre/lib/security/policy/unlimited/UnlimitedJCEPolicy.zip
      Result: True
     Comment: File /usr/local/lib/java/jre/lib/security/policy/unlimited/UnlimitedJCEPolicy.zip is not present
     Started: 19:46:15.014884
    Duration: 0.457 ms
     Changes:   
----------
          ID: download-jce-archive
    Function: cmd.run
        Name: curl -b oraclelicense=accept-securebackup-cookie -L -s -o '/usr/local/lib/java/jre/lib/security/policy/unlimited/UnlimitedJCEPolicy.zip' 'http://download.oracle.com/otn-pub/java/jdk/8/jce_policy-8.zip'
      Result: True
     Comment: Command "curl -b oraclelicense=accept-securebackup-cookie -L -s -o '/usr/local/lib/java/jre/lib/security/policy/unlimited/UnlimitedJCEPolicy.zip' 'http://download.oracle.com/otn-pub/java/jdk/8/jce_policy-8.zip'" run
     Started: 19:46:15.016123
    Duration: 3218.044 ms
     Changes:   
              ----------
              pid:
                  84275
              retcode:
                  0
              stderr:
              stdout:
----------
          ID: check-jce-archive
    Function: module.run
        Name: file.check_hash
      Result: False
     Comment: Module function file.check_hash executed
     Started: 19:46:18.235339
    Duration: 1.588 ms
     Changes:   
              ----------
              ret:
                  False
----------
          ID: backup-non-jce-jar
    Function: cmd.run
        Name: mv US_export_policy.jar US_export_policy.jar.nonjce; mv local_policy.jar local_policy.jar.nonjce;
      Result: False
     Comment: One or more requisite failed: sun-java.jce.check-jce-archive
     Changes:   
----------
          ID: unpack-jce-archive
    Function: cmd.run
        Name: unzip -j -o /usr/local/lib/java/jre/lib/security/policy/unlimited/UnlimitedJCEPolicy.zip
      Result: False
     Comment: One or more requisite failed: sun-java.jce.backup-non-jce-jar, sun-java.jce.check-jce-archive
     Changes:   
----------
          ID: remove-jce-archive
    Function: file.absent
        Name: /usr/local/lib/java/jre/lib/security/policy/unlimited/UnlimitedJCEPolicy.zip
      Result: False
     Comment: One or more requisite failed: sun-java.jce.unpack-jce-archive
     Changes:   
----------
          ID: jdk-config
    Function: file.managed
        Name: /etc/profile.d/java.sh
      Result: True
     Comment: unless condition is true
     Started: 19:46:18.238533
    Duration: 16.226 ms
     Changes:   
----------
          ID: javahome-link
    Function: file.symlink
        Name: /usr/local/lib/java
      Result: True
     Comment: Symlink /usr/local/lib/java is present and owned by root:wheel
     Started: 19:46:18.255272
    Duration: 28.964 ms
     Changes:   
----------
          ID: java-link
    Function: file.symlink
        Name: /usr/local/bin/java
      Result: True
     Comment: Created new symlink /usr/local/bin/java -> /Library/Java/JavaVirtualMachines/jdk1.8.0_172.jdk/Contents/Home/bin/java
     Started: 19:46:18.284843
    Duration: 71.504 ms
     Changes:   
              ----------
              new:
                  /usr/local/bin/java
----------
          ID: javac-link
    Function: file.symlink
        Name: /usr/local/bin/javac
      Result: True
     Comment: Created new symlink /usr/local/bin/javac -> /Library/Java/JavaVirtualMachines/jdk1.8.0_172.jdk/Contents/Home/bin/javac
     Started: 19:46:18.362174
    Duration: 2862.623 ms
     Changes:   
              ----------
              new:
                  /usr/local/bin/javac

Summary for local
-------------
Succeeded: 15 (changed=9)
Failed:     4
```