### PR TITLE
Fix issues with custom java version install

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -35,17 +35,12 @@ java:
   jce_url: http://download.oracle.com/otn-pub/java/jce/8/jce_policy-8.zip
   jce_hash: sha256=f3020a3922efd6626c2fff45695d527f34a8020e938a49292561f18ad1320b59
 
-  ## Other formula overrides ##
+  ## Other overrides ##
   java_symlink: /usr/bin/java
   javac_symlink: /usr/bin/javac
-  dl_opts: -b oraclelicense=accept-securebackup-cookie -L -s
+  dl_opts: -b oraclelicense=accept-securebackup-cookie -L -s     ## needed by oracle otn url
   archive_type: tar
 
   ## Linux alternatives
   #alt_priority: 301800111         ## value must change for all subsequent formula run
 
-  # jre_lib_sec: /usr/share/java/jre1.8.0_181/jre/lib/security
-  # java_real_home: /usr/share/java/jre1.8.0_181
-  # java_realcmd: /usr/share/java/jre1.8.0_181/bin/java
-  # javac_realcmd: /usr/share/java/jdk1.8.0_181/bin/javac
-  # java:dl_opts - cli args to cURL

--- a/pillar.example
+++ b/pillar.example
@@ -1,50 +1,51 @@
 java_home: /usr/lib/java
 # See Oracle Java SE checksums page here: https://www.oracle.com/webfolder/s/digest/8u181checksum.html
 # Use /usr/local & /Library/Java/JavaVirtualMachines for MacOS: https://support.apple.com/en-ie/HT204899
+
 java:
-  prefix: /usr/share/java
-  java_symlink: /usr/bin/java
-  javac_symlink: /usr/bin/javac
-  dl_opts: -b oraclelicense=accept-securebackup-cookie -L -s
-  archive_type: tar
+  ## override Formula default version ##
+  release: '8'
+  major: '0'
+  minor: '181'
+  build: ''    ##needed by oracle otn url (i.e. '-b13' for j8u181-b13 url)
+  dirhash: ''  ##needed by oracle otn url (i.e. '96a7b8442fe848ef90c96a2fad6ed6d1' for j8u181-b13 url)
 
-  # Enable alternatives feature by setting nonzero 'alt_priority' value here.
-  # Increase same value on each subsequent software installation.
-  # alt_priority: 301800111
+  ## tarball details
+  prefix: /usr/share/java       # ``prefix/version_name`` contains unpacked tarball content
+  version_name: jdk1.8.0_181    # JDK; value must match top-level directory inside the tarball
+  #version_name: jre1.8.0_181   # JRE; value must match top-level directory inside the tarball
 
-  ## JDK ##
-  version_name: jdk1.8.0_181
-  ## linux
-  source_url: http://download.oracle.com/otn-pub/java/jdk/8u181-b13/96a7b8442fe848ef90c96a2fad6ed6d1/jdk-8u181-linux-x64.tar.gz
+  ## JDK linux ##
+  source_url: http://download.example.com/jdk-8u181-linux-x64.tar.gz       ## can be internal (non-oracle) url
   source_hash: sha256=1845567095bfbfebd42ed0d09397939796d05456290fb20a83c476ba09f991d3
-  ## macos
-  # source_url: http://download.oracle.com/otn-pub/java/jdk/8u181-b13/96a7b8442fe848ef90c96a2fad6ed6d1/jdk-8u181-macosx-x64.dmg
+
+  ## or JDK macos ##
+  # source_url: http://download.example.com/jdk-8u181-macosx-x64.dmg       ## can be internal (non-oracle) url
   # source_hash: sha256=3ea78e0107f855b47a55414fadaabd04b94e406050d615663d54200ec85efc9b
 
-  jre_lib_sec: /usr/share/java/jdk1.8.0_181/jre/lib/security
-  java_real_home: /usr/share/java/jdk1.8.0_181
-  java_realcmd: /usr/share/java/jdk1.8.0_181/bin/java
-  javac_realcmd: /usr/share/java/jdk1.8.0_181/bin/javac
-
-  ## or JRE ##
-  # version_name: jre1.8.0_181
-  ## linux
-  # source_url: http://download.oracle.com/otn-pub/java/jdk/8u181-b13/96a7b8442fe848ef90c96a2fad6ed6d1/jre-8u181-linux-x64.tar.gz
+  ## or JRE linux ##
+  # source_url: http://download.example.com/jre-8u181-linux-x64.tar.gz       ## can be internal (non-oracle) url
   # source_hash: sha256=0b26c7fcfad20029e6e0989e678efcd4a81f0fe502a478b4972215533867de1b
-  ## macos
-  # source_url: http://download.oracle.com/otn-pub/java/jdk/8u181-b13/96a7b8442fe848ef90c96a2fad6ed6d1/jre-8u181-macosx-x64.dmg
-  # source_hash: sha256=5a107575bb6cbd953dece50399467ebcb0c7b8f7fef4d745735457842b3e03b8
 
-  # jre_lib_sec: /usr/share/java/jre1.8.0_181/jre/lib/security
-  # java_real_home: /usr/share/java/jre1.8.0_181
-  # java_realcmd: /usr/share/java/jre1.8.0_181/bin/java
-  # javac_realcmd:
+  ## or JRE macos ##
+  # source_url: http://download.oracle.com/jre-8u181-macosx-x64.dmg       ## can be internal (non-oracle) url
+  # source_hash: sha256=5a107575bb6cbd953dece50399467ebcb0c7b8f7fef4d745735457842b3e03b8
 
   ## and JCE ##
   jce_url: http://download.oracle.com/otn-pub/java/jce/8/jce_policy-8.zip
   jce_hash: sha256=f3020a3922efd6626c2fff45695d527f34a8020e938a49292561f18ad1320b59
 
-# java:version_name is the name of the top-level directory inside the tarball
-# java:prefix is where the tarball is unpacked into - prefix/version_name being
-#             the location of the jdk or jre
-# java:dl_opts - cli args to cURL
+  ## Other formula overrides ##
+  java_symlink: /usr/bin/java
+  javac_symlink: /usr/bin/javac
+  dl_opts: -b oraclelicense=accept-securebackup-cookie -L -s
+  archive_type: tar
+
+  ## Linux alternatives
+  #alt_priority: 301800111         ## value must change for all subsequent formula run
+
+  # jre_lib_sec: /usr/share/java/jre1.8.0_181/jre/lib/security
+  # java_real_home: /usr/share/java/jre1.8.0_181
+  # java_realcmd: /usr/share/java/jre1.8.0_181/bin/java
+  # javac_realcmd: /usr/share/java/jdk1.8.0_181/bin/javac
+  # java:dl_opts - cli args to cURL

--- a/sun-java/init.sls
+++ b/sun-java/init.sls
@@ -14,11 +14,11 @@ java-install-dir:
     - mode: 755
     - makedirs: True
 
-# curl fails (rc=23) if file exists (interrupte formula?)
-# and test -f cannot detect corrupted archive
-sun-java-remove-prev-archive:
+sun-java-remove-previous-os-configuration:
   file.absent:
-    - name: {{ archive_file }}
+    - names:
+      - {{ archive_file }}    #avoid rc=23 if (corrupted?) file exists.
+      - {{ java.java_home }}  #ensure file.symlink will do something
     - require:
       - file: java-install-dir
 
@@ -27,7 +27,7 @@ download-jdk-archive:
     - name: curl {{ java.dl_opts }} -o '{{ archive_file }}' '{{ java.source_url }}'
     - unless: test -f {{ java.java_realcmd }}
     - require:
-      - file: sun-java-remove-prev-archive
+      - file: sun-java-remove-previous-os-configuration
 
   {%- if java.source_hash %}
 

--- a/sun-java/settings.sls
+++ b/sun-java/settings.sls
@@ -1,15 +1,14 @@
 {% set p  = salt['pillar.get']('java', {}) %}
 {% set g  = salt['grains.get']('java', {}) %}
 
-{%- set release              = '8' %}
-{%- set major                = '0' %}
-{%- set minor                = '181' %}
-{%- set build                = '-b13' %}
-{%- set dirhash              = '/96a7b8442fe848ef90c96a2fad6ed6d1/jdk-' %}
+{%- set release              = p.get('release', '8') %}
+{%- set major                = p.get('major', '0') %}
+{%- set minor                = p.get('minor', '181') %}
+{%- set build                = p.get('build', '-b13') %}
+{%- set dirhash              = p.get('dirhash', '/96a7b8442fe848ef90c96a2fad6ed6d1') %}
 
 {# See Oracle Java SE checksums page here: https://www.oracle.com/webfolder/s/digest/8u181checksum.html #}
 {%- set default_jce_hash = 'sha256=f3020a3922efd6626c2fff45695d527f34a8020e938a49292561f18ad1320b59' %}
-
 {%- set default_version_name = 'jdk1.' + release + '.' + major + '_' + minor %}
 {%- set version_name         = g.get('version_name', p.get('version_name', default_version_name)) %}
 
@@ -34,7 +33,7 @@
 {% endif %}
 
 {%- set uri = 'http://download.oracle.com/otn-pub/java/' %}
-{%- set default_source_url = uri + 'jdk/' + release + 'u' + minor + build + dirhash + release + 'u' + minor + archive %}
+{%- set default_source_url = uri + 'jdk/' + release + 'u' + minor + build + dirhash + '/jdk-' + release + 'u' + minor + archive %}
 {%- set default_jce_url    = uri + 'jce/' + release + '/jce_policy-' + release + '.zip' %}
 {%- set default_dl_opts      = '-b oraclelicense=accept-securebackup-cookie -L -s' %}
 
@@ -63,7 +62,12 @@
 {%- set alt_priority         = g.get('alt_priority', p.get('alt_priority', None)) %}
 
 {%- set java = {} %}
-{%- do java.update( { 'version_name'   : version_name,
+{%- do java.update( { 'release'        : release,
+                      'major'          : major,
+                      'minor'          : minor,
+                      'build'          : build,
+                      'dirhash'        : dirhash,
+                      'version_name'   : version_name,
                       'source_url'     : source_url,
                       'source_hash'    : source_hash,
                       'jce_url'        : jce_url,


### PR DESCRIPTION
This PR fixes two issues noticed when using custom pillar data.  

**Issues**
a) To install a custom java version the pillar data should be updated.  But setting `source_url`, `source_hashsum`, and `version_name` pillar data is not sufficient. The correct tarball gets downloaded and installed but `settings.sls` is still using wrong (default) java version values.

b) For example if the java symlink already exists and points to some other java version, the formula does not detect this issue. The state is "successful" but symlink is wrong.

**Fixes:**
1. Make sure java version in pillar data is fully propagated to/from settings.sls. 
```
  release: '8'
  major: '0'
  minor: '181'
  build: '-b13'
  dirhash: '96a7b8442fe848ef90c96a2fad6ed6d1'        ##needed by oracle otn url
```

2. Update settings.sls - check for release, major, minor, build, dirhash pillars before using defaults and remove '/jdk-' suffix from dirhash because its not intuitive and unexpected.


3. Update init.sls - remove target symlink before `file.symlink` runs.  

4.  Update pillar.example with general edits, and ensure important pillar data is listed first.  Include the release, major, minor, build, dirhash parameters in `pillar.example`.

PR verified successfully on two Darwin OS.