### PR TITLE
Create profile file on Darwin

### DIFF
--- a/sun-java/env.sls
+++ b/sun-java/env.sls
@@ -10,7 +10,6 @@ jdk-config:
     - mode: 644
     - user: root
     - group: {{ java.group }}
-    - unless: test "`uname`" = "Darwin"
     - context:
       java_home: {{ java.java_home }}
 


### PR DESCRIPTION
This PR ensures `/etc/profile.d/java.sh` gets created on MacOS.