### PR TITLE
Add keytool funktionality

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -32,5 +32,10 @@ Downloads and installs the Java Cryptography Extension (JCE) Unlimited Strength 
 
 An addition to allow easy use - places a java profile in /etc/profile.d - this way JAVA_HOME and the PATH are set correctly for all system users.
 
+``sun-java.cacert``
+----------------
+
+An addition to allow install own CA certificates in defined keystore. If no keystore is defined, default in $JAVA_HOME/jre/lib/security/cacerts will be used. If default password for castore has been changed, provide new in pillars.
+CA certificates will only be installed if not already in keystore file.
 
 Verified on Linux and MacOS.

--- a/pillar.example
+++ b/pillar.example
@@ -10,6 +10,20 @@ java:
   build: ''    ##needed by oracle otn url (i.e. '-b13' for j8u181-b13 url)
   dirhash: ''  ##needed by oracle otn url (i.e. '96a7b8442fe848ef90c96a2fad6ed6d1' for j8u181-b13 url)
 
+  ## detials for CA certificates installation
+  cacert_keystore_password: 'changeit' ## passwort for keystore (default changeit)
+  cacert_keystore: jre_lib_sec + '/cacerts' ## location of store for ca serts
+  keytool_cmd: java_real_home + '/bin/keytool' ## location of keytool
+  cacert: ## list of certs to install
+    - alias: own-ca-cert-1 ## CA alias
+      source: https://my-ca.com/cert.crt ## location on CA cert (for file.managed)
+      source_hash: ## optional source hash on downloads
+      fingeprint: 49:72:74:18:6A:54:91:19:12:BF:09:BD:F6:F1:67:E7:30:47:3E:88 ## Fingerptint for CA cert (needed to get information if it is already installed)
+    - alias: own-ca-cert-2
+      source: salt://own-ca-cert-2
+      fingeprint: 49:72:74:18:6A:54:91:19:12:BF:09:BD:F6:F1:67:E7:30:47:3E:89
+      
+
   ## tarball details
   prefix: /usr/share/java       # ``prefix/version_name`` contains unpacked tarball content
   version_name: jdk1.8.0_181    # JDK; value must match top-level directory inside the tarball

--- a/sun-java/cacert.sls
+++ b/sun-java/cacert.sls
@@ -1,0 +1,32 @@
+{%- from 'sun-java/settings.sls' import java with context %}
+{# only run if pillars defined #}
+{%- if salt.pillar.get('java:cacert') %}
+{%- for ca in salt['pillar.fetch']('java:cacert', default=[] ) %}
+
+{# download certificate only if not already in store #}
+get-{{ca.alias}}:
+  file.managed:
+    - name: /tmp/{{ca.alias}}.tmp
+    - source: {{ca.source}}
+    {%- if ca.source_hash is defined %}
+    - source_hash: {{ca.source_hash}}
+    {%- else %}
+    - skip_verify: True
+    {%- endif %}
+    - unless: '{{java.keytool_cmd}} -list -keystore {{java.cacert_keystore}} -storepass {{java.cacert_keystore_password}} | grep -qi {{ca.fingeprint}}'
+    - require_in:
+      -file: delete-{{ca.alias}}
+{# deploy certificate if downloaded #}
+deploy-{{ca.alias}}:
+  cmd.run:
+    - name: '{{java.keytool_cmd}} -importcert -alias {{ca.alias}} -keystore {{java.cacert_keystore}} -storepass {{java.cacert_keystore_password}} -noprompt -trustcacerts -file /tmp/{{ca.alias}}.tmp'
+    - onchanges:
+      - file: get-{{ca.alias}}
+
+{# cleanup if deployed #}
+delete-{{ca.alias}}:
+  file.absent:
+    - name: /tmp/{{ca.alias}}.tmp
+
+{%- endfor %}
+{%- endif %}

--- a/sun-java/init.sls
+++ b/sun-java/init.sls
@@ -51,6 +51,11 @@ update-java-home-symlink:
     - name: {{ java.java_home }}
     - target: {{ java.java_real_home }}
 
+create-symlink-java-bin:
+  file.symlink:
+    - name: {{ java.java_real_home }}/bin/java
+    - target: /usr/bin/java
+
 remove-jdk-tarball:
   file.absent:
     - name: {{ tarball_file }}

--- a/sun-java/init.sls
+++ b/sun-java/init.sls
@@ -53,8 +53,8 @@ update-java-home-symlink:
 
 create-symlink-java-bin:
   file.symlink:
-    - name: {{ java.java_real_home }}/bin/java
-    - target: /usr/bin/java
+    - name: /usr/bin/java 
+    - target: {{ java.java_real_home }}/bin/java
 
 remove-jdk-tarball:
   file.absent:

--- a/sun-java/settings.sls
+++ b/sun-java/settings.sls
@@ -1,7 +1,7 @@
 {% set p  = salt['pillar.get']('java', {}) %}
 {% set g  = salt['grains.get']('java', {}) %}
 
-{%- set java_home            = salt['grains.get']('java_home', salt['pillar.get']('java_home', '/usr/lib/java')) %}
+{%- set java_home            = salt['grains.get']('java_home', salt['pillar.get']('java_home', '/usr/lib/jvm')) %}
 
 {%- set default_version_name = 'jdk1.8.0_74' %}
 {%- set default_prefix       = '/usr/share/java' %}

--- a/sun-java/settings.sls
+++ b/sun-java/settings.sls
@@ -11,6 +11,7 @@
 {%- set default_jce_hash = 'sha256=f3020a3922efd6626c2fff45695d527f34a8020e938a49292561f18ad1320b59' %}
 {%- set default_version_name = 'jdk1.' + release + '.' + major + '_' + minor %}
 {%- set version_name         = g.get('version_name', p.get('version_name', default_version_name)) %}
+{%- set default_cacert_keystore_password = 'changeit' %}
 
 {% if grains.os == 'MacOS' %}
   {% set archive = '-macosx-x64.dmg' %}
@@ -61,6 +62,11 @@
 {%- set javac_realcmd        = java_realcmd + 'c' %}
 {%- set alt_priority         = g.get('alt_priority', p.get('alt_priority', None)) %}
 
+{# Variables for deployment own CA certificates #}
+{%- set cacert_keystore        = p.get('cacert_keystore', jre_lib_sec + '/cacerts') %}
+{%- set cacert_keystore_password        = p.get('cacert_keystore_password', 'changeit' ) %}
+{%- set keytool_cmd         = p.get('keytool_cmd', java_real_home + '/bin/keytool' ) %}
+
 {%- set java = {} %}
 {%- do java.update( { 'release'        : release,
                       'major'          : major,
@@ -84,4 +90,7 @@
                       'javac_symlink'  : javac_symlink,
                       'javac_realcmd'  : javac_realcmd,
                       'alt_priority'   : alt_priority,
+                      'cacert_keystore'   : cacert_keystore,
+                      'cacert_keystore_password'   : cacert_keystore_password,
+                      'keytool_cmd'   : keytool_cmd,
                     } ) %}


### PR DESCRIPTION
We extended sun-java formula to be able manage (add only) own CA certificates in java keystore.
See Readme and also pillar.example for more details