### PR TITLE
Fix JCE - 'No such file or directory' on MacOS

### DIFF
--- a/sun-java/jce.sls
+++ b/sun-java/jce.sls
@@ -60,6 +60,9 @@ backup-non-jce-jar:
     - name:
       - mv {{ us_policy_jar }} {{ us_policy_jar }}.nonjce
       - mv {{ local_policy_jar }} {{ local_policy_jar }}.nonjce
+    - creates:
+      - {{ us_policy_jar }}.nonjce
+      - {{ local_policy_jar }}.nonjce
     - onlyif:
       - test -f {{ us_policy_jar }}
       - test -f {{ local_policy_jar }}


### PR DESCRIPTION
The backup-non-jce-jar state is failing on MacOS with "No such file or Directory".

This PR is minor update to ensure state can find policy files.

Verified on MacOS and Ubuntu 18.04 - works fine.