### PR TITLE
fix(cmdrun): fix cmd.run syntax error

### DIFF
--- a/sun-java/jce.sls
+++ b/sun-java/jce.sls
@@ -57,7 +57,7 @@ check-jce-archive:
 
 backup-non-jce-jar:
   cmd.run:
-    - name:
+    - names:
       - mv {{ us_policy_jar }} {{ us_policy_jar }}.nonjce
       - mv {{ local_policy_jar }} {{ local_policy_jar }}.nonjce
     - creates:


### PR DESCRIPTION
This PR fixes a syntax bug:

```
          ID: backup-non-jce-jar
    Function: cmd.run
      Result: False
     Comment: Command "backup-non-jce-jar" run
     Started: 13:13:17.553015
    Duration: 16.805 ms
     Changes:
              ----------
              pid:
                  36242
              retcode:
                  127
              stderr:
                  /bin/sh: backup-non-jce-jar: command not found
              stdout:
```