### PR TITLE
fix(corruption): delete file if hashcheck fails

### DIFF
--- a/sun-java/init.sls
+++ b/sun-java/init.sls
@@ -47,6 +47,11 @@ check-jdk-archive:
       - cmd: download-jdk-archive
     - require_in:
       - archive: unpack-jdk-archive
+# Get rid of corrupted file so state rerun does fresh download.
+  file.absent:
+    - name: {{ archive_file }}
+    - onfail:
+      - module: check-jdk-archive
 
   {%- endif %}
 

--- a/sun-java/jce.sls
+++ b/sun-java/jce.sls
@@ -52,6 +52,11 @@ check-jce-archive:
     - require_in:
       - cmd: backup-non-jce-jar
       - cmd: unpack-jce-archive
+# Get rid of corrupted file so state rerun does fresh download.
+  file.absent:
+    - name: {{ archive_file }}
+    - onfail:
+      - module: check-jce-archive
 
   {%- endif %}
 


### PR DESCRIPTION
Allow for successful rerun `init` and `jce` states if previous state run failed a hashcheck.
Resolves #77 