### PR TITLE
fix(bug): jce.sls: rename zip_file variable to archive_file

### DIFF
--- a/sun-java/jce.sls
+++ b/sun-java/jce.sls
@@ -2,7 +2,7 @@
 
 {%- if java.jce_url is defined %}
 
-  {%- set zip_file = salt['file.join'](java.jre_lib_sec, 'UnlimitedJCEPolicy.zip') %}
+  {%- set archive_file = salt['file.join'](java.jre_lib_sec, 'UnlimitedJCEPolicy.zip') %}
   {%- set us_policy_jar = salt['file.join'](java.jre_lib_sec, 'US_export_policy.jar') %}
   {%- set local_policy_jar = salt['file.join'](java.jre_lib_sec, 'local_policy.jar') %}
 
@@ -18,9 +18,9 @@ download-jce-archive:
     - name: {{ java.jre_lib_sec }}
     - makedirs: True
   cmd.run:
-    - name: curl {{ java.dl_opts }} -o '{{ zip_file }}' '{{ java.jce_url }}'
-    - unless: test -f {{ zip_file }}
-    - creates: {{ zip_file }}
+    - name: curl {{ java.dl_opts }} -o '{{ archive_file }}' '{{ java.jce_url }}'
+    - unless: test -f {{ archive_file }}
+    - creates: {{ archive_file }}
     - onlyif: >
         test ! -f {{ us_policy_jar }} ||
         test ! -f {{ us_policy_jar }}.nonjce
@@ -45,7 +45,7 @@ download-jce-archive:
 check-jce-archive:
   module.run:
     - name: file.check_hash
-    - path: {{ zip_file }}
+    - path: {{ archive_file }}
     - file_hash: {{ java.jce_hash }}
     - require:
       - cmd: download-jce-archive
@@ -76,7 +76,7 @@ backup-non-jce-jar:
 
 unpack-jce-archive:
   cmd.run:
-    - name: unzip -j -o {{ zip_file }}
+    - name: unzip -j -o {{ archive_file }}
     - cwd: {{ java.jre_lib_sec }}
     - creates:
       - {{ us_policy_jar }}


### PR DESCRIPTION
### PR progress checklist (to be filled in by reviewers)

- [x] Changes to documentation are appropriate (or tick if not required)
- [x] Changes to tests are appropriate (or tick if not required)
- [ ] Reviews completed

---

### What type of PR is this?
#### Primary type
<!-- There really should be only *one* of these types ticked for each PR. -->

- [ ] `[build]`    Changes related to the build system
- [ ] `[chore]`    Changes to the build process or auxiliary tools and libraries such as documentation generation
- [ ] `[ci]`       Changes to the continuous integration configuration
- [ ] `[feat]`     A new feature
- [x] `[fix]`      A bug fix
- [ ] `[perf]`     A code change that improves performance
- [ ] `[refactor]` A code change that neither fixes a bug nor adds a feature
- [ ] `[revert]`   A change used to revert a previous commit
- [ ] `[style]`    Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc.)

#### Secondary type
<!-- Most PRs should include all of the following types as well. -->

- [ ] `[docs]`     Documentation changes
- [ ] `[test]`     Adding missing or correcting existing tests

### Does this PR introduce a `BREAKING CHANGE`?
No.

### Related issues and/or pull requests

#78 causes #79 



### Describe the changes you're proposing

Fix undefined variable in jce.sls

### Pillar / config required to test the proposed changes



### Debug log showing how the proposed changes work



### Documentation checklist

- [ ] Updated the `README` (e.g. `Available states`).
- [ ] Updated `pillar.example`.

### Testing checklist
<!-- Please tick each box that is relevant (after creating the PR). -->

- [ ] Included in Kitchen (i.e. under `state_top`).
- [ ] Covered by new/existing tests (e.g. InSpec, Serverspec, etc.).
- [ ] Updated the relevant test pillar.

### Additional context
<!-- Add any other context about the proposed changes here. -->


